### PR TITLE
Fix link to Spectrum chat

### DIFF
--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -3,5 +3,5 @@ title: "Contact"
 date: 2018-09-09T18:19:33+06:00
 ---
 
-If you have specific technical questions please ask in the [Spectrum room](https://spectrum.chat/graphql-java/) or open an [issue on GitHub](https://github.com/graphql-java/graphql-java/issues).
+If you have specific technical questions please ask in the [Spectrum room](https://spectrum.chat/graphql-java) or open an [issue on GitHub](https://github.com/graphql-java/graphql-java/issues).
 


### PR DESCRIPTION
Link with slash at end of URL redirect to home page of Spectrum chat ("Explore"). Only link without slash is correct URL to Spectrum room (in this case "GraphQL Java").