### PR TITLE
Fix Typo in Docs

### DIFF
--- a/content/documentation/v13/data-fetching.md
+++ b/content/documentation/v13/data-fetching.md
@@ -175,7 +175,7 @@ top level fields.  The root object never changes during the query and it may be 
 arguments that have been resolved from passed in variables, AST literals and default argument values.  You use the arguments
 of a field to control what values it returns.
 
-* ``<T> T getContext()`` - the context is object is set up when the query is first executed and stays the same over the lifetime
+* ``<T> T getContext()`` - the context object is set up when the query is first executed and stays the same over the lifetime
 of the query.  The context can be any value and is typically used to give each data fetcher some calling context needed
 when trying to get field data.  For example the current user credentials or the database connection parameters could be contained
 with a ``context`` object so that data fetchers can make business layer calls.  One of the key design decisions you have as a graphql


### PR DESCRIPTION
Changes, _the context is object is_ to _the context object is_.