### PR TITLE
Fix a typo in the v16 getting started Maven code block

### DIFF
--- a/content/documentation/v16/getting-started.md
+++ b/content/documentation/v16/getting-started.md
@@ -42,7 +42,7 @@ Dependency:
     <dependency>
         <groupId>com.graphql-java</groupId>
         <artifactId>graphql-java</artifactId>
-        <version>16.2/version>
+        <version>16.2</version>
     </dependency>
 {{< / highlight >}}
 


### PR DESCRIPTION
Not quite sure which branch should it point to, would be grateful if a maintainer could help me out with that.