### PR TITLE
Fix Maven versions and add Gradle KTS examples

### DIFF
--- a/documentation/getting-started.mdx
+++ b/documentation/getting-started.mdx
@@ -7,25 +7,45 @@ description: GraphQL basics. Start here if you're new to GraphQL :-)
 
 # Getting started
 
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
 `graphql-java` requires at least Java 8.
 
 ## How to use the latest release with Gradle
 
-Make sure ``mavenCentral`` is among your repos:
+Make sure `mavenCentral` is among your repos:
 
-```groovy
+<Tabs groupId="gradle-language">
+<TabItem value="groovy" label="Gradle">
+
+```groovy {6}
 repositories {
     mavenCentral()
 }
-```
 
-Dependency:
-
-```groovy
 dependencies {
-    compile 'com.graphql-java:graphql-java:16.2'
+    implementation 'com.graphql-java:graphql-java:17.3'
 }
 ```
+
+</TabItem>
+<TabItem value="kotlin" label="Gradle (Kotlin)">
+
+```kotlin {6}
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.graphql-java:graphql-java:17.3")
+}
+```
+
+</TabItem>
+</Tabs>
 
 ## How to use the latest release with Maven
 
@@ -34,7 +54,7 @@ Dependency:
 <dependency>
     <groupId>com.graphql-java</groupId>
     <artifactId>graphql-java</artifactId>
-    <version>16.2</version>
+    <version>17.3</version>
 </dependency>
 ```
 

--- a/documentation/getting-started.mdx
+++ b/documentation/getting-started.mdx
@@ -108,22 +108,42 @@ latest version value.
 
 ### How to use the latest build with Gradle
 
-Add the repositories:
+Add the required repository and dependency to your Gradle build file:
+
+<Tabs groupId="gradle-language">
+<TabItem value="groovy" label="Gradle">
 
 ```groovy
 repositories {
     mavenCentral()
-    maven { url  "https://dl.bintray.com/andimarek/graphql-java" }
+    maven {
+        url 'https://dl.bintray.com/andimarek/graphql-java'
+    }
 }
-```
 
-Dependency:
-
-```groovy
 dependencies {
-    compile 'com.graphql-java:graphql-java:INSERT_LATEST_VERSION_HERE'
+    implementation 'com.graphql-java:graphql-java:INSERT_LATEST_VERSION_HERE'
 }
 ```
+
+</TabItem>
+<TabItem value="kotlin" label="Gradle (Kotlin)">
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://dl.bintray.com/andimarek/graphql-java")
+    }
+}
+
+dependencies {
+    implementation("com.graphql-java:graphql-java:INSERT_LATEST_VERSION_HERE")
+}
+```
+
+</TabItem>
+</Tabs>
 
 ### How to use the latest build with Maven
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -127,7 +127,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ['java', 'groovy'],
+        additionalLanguages: ['java', 'groovy', 'kotlin'],
       },
       googleAnalytics: {
         trackingID: 'UA-126627606-1',

--- a/versioned_docs/version-v16/getting-started.mdx
+++ b/versioned_docs/version-v16/getting-started.mdx
@@ -1,33 +1,52 @@
 ---
 title: "Getting started"
 date: 2018-09-09T12:52:46+10:00
-description: GraphQL basics. Start here if you're new to GraphQL :-) 
+description: GraphQL basics. Start here if you're new to GraphQL :-)
 sidebar_position: 1
 ---
+
 # Getting started
+
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
 
 `graphql-java` requires at least Java 8.
 
 
 ## How to use the latest release with Gradle
 
-Make sure ``mavenCentral`` is among your repos:
+Make sure `mavenCentral` is among your repos:
 
-```groovy
+<Tabs groupId="gradle-language">
+<TabItem value="groovy" label="Gradle">
+
+```groovy {6}
 repositories {
     mavenCentral()
 }
-```
 
-
-Dependency:
-
-```groovy
 dependencies {
-  compile 'com.graphql-java:graphql-java:16.2'
+    implementation 'com.graphql-java:graphql-java:16.2'
 }
 ```
 
+</TabItem>
+<TabItem value="kotlin" label="Gradle (Kotlin)">
+
+```kotlin {6}
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.graphql-java:graphql-java:16.2")
+}
+```
+
+</TabItem>
+</Tabs>
 
 ## How to use the latest release with Maven
 
@@ -137,3 +156,6 @@ Dependency:
     <version>INSERT_LATEST_VERSION_HERE</version>
 </dependency>
 ```
+
+
+

--- a/versioned_docs/version-v16/getting-started.mdx
+++ b/versioned_docs/version-v16/getting-started.mdx
@@ -112,24 +112,42 @@ latest version value.
 
 ### How to use the latest build with Gradle
 
-Add the repositories:
+Add the required repository and dependency to your Gradle build file:
+
+<Tabs groupId="gradle-language">
+<TabItem value="groovy" label="Gradle">
 
 ```groovy
 repositories {
     mavenCentral()
-    maven { url  "https://dl.bintray.com/andimarek/graphql-java" }
+    maven {
+        url 'https://dl.bintray.com/andimarek/graphql-java'
+    }
 }
-```
 
-Dependency:
-
-```groovy
 dependencies {
-  compile 'com.graphql-java:graphql-java:INSERT_LATEST_VERSION_HERE'
+    implementation 'com.graphql-java:graphql-java:INSERT_LATEST_VERSION_HERE'
 }
 ```
 
+</TabItem>
+<TabItem value="kotlin" label="Gradle (Kotlin)">
 
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://dl.bintray.com/andimarek/graphql-java")
+    }
+}
+
+dependencies {
+    implementation("com.graphql-java:graphql-java:INSERT_LATEST_VERSION_HERE")
+}
+```
+
+</TabItem>
+</Tabs>
 
 ### How to use the latest build with Maven
 

--- a/versioned_docs/version-v17/getting-started.mdx
+++ b/versioned_docs/version-v17/getting-started.mdx
@@ -1,33 +1,52 @@
 ---
 title: "Getting started"
 date: 2018-09-09T12:52:46+10:00
-description: GraphQL basics. Start here if you're new to GraphQL :-) 
+description: GraphQL basics. Start here if you're new to GraphQL :-)
 sidebar_position: 1
 ---
+
 # Getting started
+
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
 
 `graphql-java` requires at least Java 8.
 
 
 ## How to use the latest release with Gradle
 
-Make sure ``mavenCentral`` is among your repos:
+Make sure `mavenCentral` is among your repos:
 
-```groovy
+<Tabs groupId="gradle-language">
+<TabItem value="groovy" label="Gradle">
+
+```groovy {6}
 repositories {
     mavenCentral()
 }
-```
 
-
-Dependency:
-
-```groovy
 dependencies {
-  compile 'com.graphql-java:graphql-java:16.2'
+    implementation 'com.graphql-java:graphql-java:17.3'
 }
 ```
 
+</TabItem>
+<TabItem value="kotlin" label="Gradle (Kotlin)">
+
+```kotlin {6}
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.graphql-java:graphql-java:17.3")
+}
+```
+
+</TabItem>
+</Tabs>
 
 ## How to use the latest release with Maven
 
@@ -137,6 +156,3 @@ Dependency:
     <version>INSERT_LATEST_VERSION_HERE</version>
 </dependency>
 ```
-
-
-

--- a/versioned_docs/version-v17/getting-started.mdx
+++ b/versioned_docs/version-v17/getting-started.mdx
@@ -112,24 +112,42 @@ latest version value.
 
 ### How to use the latest build with Gradle
 
-Add the repositories:
+Add the required repository and dependency to your Gradle build file:
+
+<Tabs groupId="gradle-language">
+<TabItem value="groovy" label="Gradle">
 
 ```groovy
 repositories {
     mavenCentral()
-    maven { url  "https://dl.bintray.com/andimarek/graphql-java" }
+    maven {
+        url 'https://dl.bintray.com/andimarek/graphql-java'
+    }
 }
-```
 
-Dependency:
-
-```groovy
 dependencies {
-  compile 'com.graphql-java:graphql-java:INSERT_LATEST_VERSION_HERE'
+    implementation 'com.graphql-java:graphql-java:INSERT_LATEST_VERSION_HERE'
 }
 ```
 
+</TabItem>
+<TabItem value="kotlin" label="Gradle (Kotlin)">
 
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://dl.bintray.com/andimarek/graphql-java")
+    }
+}
+
+dependencies {
+    implementation("com.graphql-java:graphql-java:INSERT_LATEST_VERSION_HERE")
+}
+```
+
+</TabItem>
+</Tabs>
 
 ### How to use the latest build with Maven
 


### PR DESCRIPTION
Examples:

Groovy:
![Gradle Groovy](https://user-images.githubusercontent.com/30464310/142616157-d19c39ac-2711-4cd9-8e1e-448e19938141.png)


Kotlin:
![Gradle KTS](https://user-images.githubusercontent.com/30464310/142616194-fbfe08e1-0fed-4ecc-987d-270e1fb15b29.png)
