### PR TITLE
Add clarification blog on Spring integration recommendation

### DIFF
--- a/blog/2022-09-20-spring-for-graphql-naming.md
+++ b/blog/2022-09-20-spring-for-graphql-naming.md
@@ -1,6 +1,6 @@
 ---
 title: "Spring for GraphQL is the recommended Spring integration"
-authors: andi
+authors: donna
 slug: spring-for-graphql
 ---
 
@@ -10,6 +10,6 @@ Use [Spring Initializr](https://start.spring.io/) to create a GraphQL applicatio
 
 See also the Spring for GraphQL [documentation](https://docs.spring.io/spring-graphql/docs/current/reference/html/) and the repo on [GitHub](https://github.com/spring-projects/spring-graphql).
 
-Before the official Spring for GraphQL integration was released, there were many other GraphQL integrations for Spring, including the similarly and confusingly named [GraphQL Java Spring](https://github.com/graphql-java/graphql-java-spring) project from the GraphQL Java team, published under the `com.graphql-java` group ID. Many tutorials are still referring to this archived and unrelated project.
+Before the official Spring for GraphQL integration was released, there were many other GraphQL integrations for Spring, including the similarly named [GraphQL Java Spring](https://github.com/graphql-java-kickstart/graphql-spring-boot) project from the GraphQL Java team, published under the `com.graphql-java` and `com.graphql-java-kickstart` group IDs. Many tutorials are still referring to this unrelated project.
 
-To avoid confusion, please use the official integration named **"Spring for GraphQL"**, published under `org.springframework` and related group IDs.
+Please use the official integration named **"Spring for GraphQL"**, published under `org.springframework` and related group IDs.

--- a/blog/2022-09-20-spring-for-graphql-naming.md
+++ b/blog/2022-09-20-spring-for-graphql-naming.md
@@ -1,0 +1,15 @@
+---
+title: "Spring for GraphQL is the recommended Spring integration"
+authors: andi
+slug: spring-for-graphql
+---
+
+If you are building a GraphQL application with Spring, we recommend using the official [Spring for GraphQL](https://spring.io/projects/spring-graphql) integration. This integration is a collaboration between the Spring and GraphQL Java teams, and is maintained by the Spring team. In May 2022, Spring for GraphQL 1.0 GA was [released](https://spring.io/blog/2022/05/19/spring-for-graphql-1-0-release).
+
+Use [Spring Initializr](https://start.spring.io/) to create a GraphQL application. For a quick tutorial, please see our [Spring for GraphQL tutorial](https://www.graphql-java.com/tutorials/getting-started-with-spring-boot).
+
+See also the Spring for GraphQL [documentation](https://docs.spring.io/spring-graphql/docs/current/reference/html/) and the repo on [GitHub](https://github.com/spring-projects/spring-graphql).
+
+Before the official Spring for GraphQL integration was released, there were many other GraphQL integrations for Spring, including the similarly and confusingly named [GraphQL Java Spring](https://github.com/graphql-java/graphql-java-spring) project from the GraphQL Java team, published under the `com.graphql-java` group ID. Many tutorials are still referring to this archived and unrelated project.
+
+To avoid confusion, please use the official integration named **"Spring for GraphQL"**, published under `org.springframework` and related group IDs.

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,4 +1,3 @@
-# TODO: add authors
 andi:
   name: Andreas Marek
   title: Maintainer of GraphQL Java
@@ -10,3 +9,8 @@ brad:
   title: Maintainer of GraphQL Java
   url: https://github.com/bbakerman
   image_url: https://github.com/bbakerman.png
+
+donna:
+  name: Donna Zhou
+  url: https://github.com/dondonz
+  image_url: https://github.com/dondonz.png


### PR DESCRIPTION
Draft blog clarifying confusion regarding name of current Spring integration. "Spring for GraphQL" is the official Spring integration.