### PR TITLE
Fix Query Caching section so that example code compiles

### DIFF
--- a/documentation/execution.md
+++ b/documentation/execution.md
@@ -465,9 +465,9 @@ Cache<String, PreparsedDocumentEntry> cache = Caffeine.newBuilder().maximumSize(
 
 PreparsedDocumentProvider preparsedCache = new PreparsedDocumentProvider() {
     @Override
-    public PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
+    public CompletableFuture<PreparsedDocumentEntry> getDocumentAsync(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
             Function<String, PreparsedDocumentEntry> mapCompute = key -> computeFunction.apply(executionInput);
-            return cache.get(executionInput.getQuery(), mapCompute);
+            return CompletableFuture.completedFuture(cache.get(executionInput.getQuery(), mapCompute));
     }
 };
 

--- a/versioned_docs/version-v22/execution.md
+++ b/versioned_docs/version-v22/execution.md
@@ -465,9 +465,9 @@ Cache<String, PreparsedDocumentEntry> cache = Caffeine.newBuilder().maximumSize(
 
 PreparsedDocumentProvider preparsedCache = new PreparsedDocumentProvider() {
     @Override
-    public PreparsedDocumentEntry getDocument(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
+    public CompletableFuture<PreparsedDocumentEntry> getDocumentAsync(ExecutionInput executionInput, Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
             Function<String, PreparsedDocumentEntry> mapCompute = key -> computeFunction.apply(executionInput);
-            return cache.get(executionInput.getQuery(), mapCompute);
+            return CompletableFuture.completedFuture(cache.get(executionInput.getQuery(), mapCompute));
     }
 };
 


### PR DESCRIPTION
Version 22.0 of `graphql-java` removed a deprecated method from the `PreparsedDocumentProvider` interface.

This means that the example code for setting up a Query Cache, which used the deprecated method, no longer compiles.

This PR updates the documentation so that it will compile.

Note that I'm not sure whether there's a better solution than using `CompletableFuture.completedFuture()`, so open to suggestions.
