### PR TITLE
Add CNA blog and security information

### DIFF
--- a/blog/2024-12-07-cve-numbering-authority.md
+++ b/blog/2024-12-07-cve-numbering-authority.md
@@ -1,0 +1,9 @@
+---
+title: "GraphQL Java is a CVE Numbering Authority"
+authors: donna
+slug: cna
+---
+
+We are please to announce GraphQL Java is now the CVE Numbering Authority (CNA) for GraphQL Java, Java DataLoader, GraphQL Java Extended Scalars, and GraphQL Java Extended Validation.
+
+See the CVE.org press release: https://www.cve.org/Media/News/item/news/2024/12/03/GraphQL-Java-Added-as-CNA

--- a/src/pages/security.md
+++ b/src/pages/security.md
@@ -29,6 +29,8 @@ Please allow time for the maintainers to review vulnerability reports, please no
 
 ## Common Vulnerabilities and Exposures (CVEs)
 
+[GraphQL Java is the CVE Numbering Authority (CNA)](https://www.cve.org/PartnerInformation/ListofPartners/partner/graphql-java) for GraphQL Java, Java DataLoader, GraphQL Java Extended Scalars, and GraphQL Java Extended Validation.
+
 #### CVE-2024-40094
 Patched by versions 21.5, 20.9, 19.11, build version 0.0.0-2024-03-22T04-18-12-97743bc, or later
 * [Announcement on GitHub](https://github.com/graphql-java/graphql-java/discussions/3641)


### PR DESCRIPTION
Announcing GraphQL Java is now a CVE Numbering Authority