### PR TITLE
Fix hero CTA hover styles

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -65,7 +65,9 @@
 }
 
 .ctaPrimary:hover {
+  color: #E91E8C;
   background: rgba(255, 255, 255, 0.92);
+  text-decoration: none;
 }
 
 .ctaSecondary {
@@ -76,7 +78,9 @@
 }
 
 .ctaSecondary:hover {
+  color: white;
   background: rgba(255, 255, 255, 0.08);
+  text-decoration: none;
 }
 
 /* Content */
@@ -119,6 +123,7 @@
 .card:hover {
   border-color: #ccc;
   background: #fafafa;
+  text-decoration: none;
 }
 
 .cardTitle {
@@ -186,7 +191,9 @@
 }
 
 .federationBtn:hover {
+  color: white;
   background: #d01a7e;
+  text-decoration: none;
 }
 
 /* Dark mode */


### PR DESCRIPTION
## Summary

- Restores `color` and `text-decoration: none` on `.ctaPrimary:hover`, `.ctaSecondary:hover`, `.card:hover`, and `.federationBtn:hover`
- Docusaurus's global `a:hover` rule adds underline and overrides link color — hover rules must explicitly counter this or buttons show underlines and wrong text colors on hover

## Test plan

- [ ] Hover "Get started →" (primary CTA) — stays white background, pink text, no underline
- [ ] Hover "JVM-native GraphQL federation" (secondary CTA) — stays transparent with white text, no underline
- [ ] Hover doc/community cards — no underline
- [ ] Hover "feddi.dev" federation button — stays white text, no underline

🤖 Generated with [Claude Code](https://claude.com/claude-code)