### PR TITLE
Add UTM parameters to feddi.dev links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,7 +111,7 @@ const config = {
           },
           {href: 'https://leanpub.com/graphql-java/', label: 'Book', position: 'left'},
           {to: '/tutorials/getting-started-with-spring-boot', label: 'Tutorial', position: 'left'},
-          {href: 'https://feddi.dev', label: 'Federation', position: 'left', className: 'navbar-federation-link'},
+          {href: 'https://feddi.dev?utm_source=graphql_java_com&utm_medium=website&utm_campaign=site_referral&utm_content=navbar', label: 'Federation', position: 'left', className: 'navbar-federation-link'},
           {to: '/blog', label: 'Blog', position: 'left'},
           {to: '/security', label: 'Security', position: 'left'},
           {to: '/about', label: 'About', position: 'left'},

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,7 +24,7 @@ function Hero() {
         <Link className={styles.ctaPrimary} to="/documentation/getting-started">
           Get started →
         </Link>
-        <a className={styles.ctaSecondary} href="https://feddi.dev" {...EXT_LINK}>
+        <a className={styles.ctaSecondary} href="https://feddi.dev?utm_source=graphql_java_com&utm_medium=website&utm_campaign=site_referral&utm_content=hero_cta" {...EXT_LINK}>
           JVM-native GraphQL federation <ExtIcon />
         </a>
       </div>
@@ -75,7 +75,7 @@ export default function Home() {
                 Andreas Marek, creator of GraphQL Java, is building feddi — a JVM-native federation gateway for any team running GraphQL on the JVM.
               </div>
             </div>
-            <a className={styles.federationBtn} href="https://feddi.dev" {...EXT_LINK}>
+            <a className={styles.federationBtn} href="https://feddi.dev?utm_source=graphql_java_com&utm_medium=website&utm_campaign=site_referral&utm_content=federation_section" {...EXT_LINK}>
               feddi.dev <ExtIcon />
             </a>
           </div>

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -34,7 +34,7 @@ export default function Footer() {
               <li><a className={styles.link} href="https://javadoc.io/doc/com.graphql-java/graphql-java/" {...EXT_LINK}>JavaDoc<FooterExtIcon /></a></li>
               <li><Link className={styles.link} to="/security">Security</Link></li>
               <li>
-                <a className={`${styles.link} ${styles.federationLink}`} href="https://feddi.dev" {...EXT_LINK}>
+                <a className={`${styles.link} ${styles.federationLink}`} href="https://feddi.dev?utm_source=graphql_java_com&utm_medium=website&utm_campaign=site_referral&utm_content=footer" {...EXT_LINK}>
                   Federation<FooterExtIcon />
                 </a>
               </li>


### PR DESCRIPTION
## Summary

- Adds UTM params to all four `feddi.dev` links (navbar, hero CTA, federation section, footer)
- Consistent params: `utm_source=graphql_java_com`, `utm_medium=website`, `utm_campaign=site_referral`
- `utm_content` differentiates each placement: `navbar`, `hero_cta`, `federation_section`, `footer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)